### PR TITLE
fix: 修复引用类型初始为空取值错误

### DIFF
--- a/src/lib/Heap/index.ts
+++ b/src/lib/Heap/index.ts
@@ -57,7 +57,7 @@ class Heap {
     } else if (propTypes[name] === Number) {
       return (Number(value) as unknown) as ValueOf<Props>;
     }
-    if (this.dataMap[value]) {
+    if (Object.prototype.hasOwnProperty.call(this.dataMap, value)) {
       // 放在堆中的引用类型数据
       const heapValue = this.dataMap[value];
       // 取出即回收


### PR DESCRIPTION
#### 问题
我的 magic React 组件写法：
```javascript
import React, { createElement } from 'react';
import ReactDOM from 'react-dom';

// 定义组件
const Hello = ({ test }) => {
  // test 初始值为 null，这里应该没有任何展示
  // 由于 magic 内部处理问题，test 并不会返回 null，而是一个唯一的 hash 值
  return <div>{ test?.name ? test.name : test }</div>
}

// 挂载
export function mount(container, props) {
  ReactDOM.render(createElement(Hello, props, null), container);
}

// 更新
export function updated(attrName, value, container, props) {
  ReactDOM.render(createElement(Hello, props, null), container);
}
```
自定义 magic 组件 Vue 中使用姿势：
``` javascript
magic('react-hello', ReactHello, {
  propTypes: {
    test: Object
  },
  shadow: true
});

<template>
  <div>
    <div @click="changeName">赋值</div>
    <react-hello :test="useProps(test)"></react-hello>
  </div>
</template>
<script>
import { useProps } from '@magic-microservices/magic';
export default {
  data() {
    return {
      test: null
    }
  },

  methods: {
    useProps,

    changeName() {
      this.test = { name: 'magic' }
    }
  }
}
</script>

```
浏览器渲染效果：
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/30647295/167631920-7d975399-44e0-4ced-89c9-f19b93e1c9d7.png">
https://user-images.githubusercontent.com/30647295/167631457-f32245ba-1c39-42ec-8322-2561a139e17b.mp4

#### 修复方式

src/lib/Heap/index.ts 的 getPropsValue 方法中，从 heap 取值时，判断条件更改为 dataMap 是否存在对应的 key