### PR TITLE
Fix/react event

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",
     "@types/jest": "^26.0.15",
+    "@types/react-shadow-dom-retarget-events": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
     "babel-eslint": "^10.1.0",
@@ -117,6 +118,7 @@
     "validate-commit-msg": "^2.14.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0"
+    "@babel/runtime": "^7.12.0",
+    "react-shadow-dom-retarget-events": "^1.1.0"
   }
 }

--- a/src/lib/Heap/index.ts
+++ b/src/lib/Heap/index.ts
@@ -57,7 +57,7 @@ class Heap {
     } else if (propTypes[name] === Number) {
       return (Number(value) as unknown) as ValueOf<Props>;
     }
-    if (this.dataMap[value]) {
+    if (Object.prototype.hasOwnProperty.call(this.dataMap, value)) {
       // 放在堆中的引用类型数据
       const heapValue = this.dataMap[value];
       // 取出即回收

--- a/src/lib/LifeCycle/index.ts
+++ b/src/lib/LifeCycle/index.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import retargetEvents from 'react-shadow-dom-retarget-events';
 import functionExecutor from '@/utils/functionExecutor';
 import {
   createHtmlTagObject,
@@ -139,7 +140,16 @@ export default class LifeCycle<Props extends {} = Record<string, unknown>> {
 
       constructor() {
         super();
-        this.webComponentsIns = options.shadow ? this.attachShadow({ mode: 'open' }) : this;
+        this.webComponentsIns = this;
+        if (options.shadow) {
+          this.webComponentsIns = this.attachShadow({ mode: 'open' });
+
+          /**
+           * 兼容 React17 之前 SyntheticEvent 合成事件机制
+           * https://github.com/facebook/react/issues/10422
+           */
+          retargetEvents(this.webComponentsIns);
+        }
         module.bootstrap && module.bootstrap(this);
       }
 


### PR DESCRIPTION
### 问题
组件使用 magic 处理，react 17 之前，事件不生效。
具体可参考 react [官方 Issues](https://github.com/facebook/react/issues/10422)

### 解决方案
基于 react-shadow-dom-retarget-events 库进行兼容处理 