### PR TITLE
feat: enhance plugins

### DIFF
--- a/tests/magic.spec.ts
+++ b/tests/magic.spec.ts
@@ -4,8 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import magic, { useProps, isModuleRegistered, MagicInstanceType } from '@/index';
-import LifeCycle from '@/lib/LifeCycle';
+import magic, { useProps, isModuleRegistered, MagicInstanceType, LifeCycle } from '@/index';
 
 const componentTag = 'my-component';
 const shadowComponentTag = 'my-component-shadow';
@@ -168,25 +167,41 @@ describe('test magic', () => {
   });
 
   test('test plugins', (done) => {
-    interface testLifeCycleType extends LifeCycle<Record<string, unknown>> {
-      test: number;
-    }
+    type testLifeCycle = LifeCycle & { test: number };
+    type testMagicInstanceType = MagicInstanceType & { test: number };
     const test = 1;
     class MagicPlugin {
-      apply(lifeCycle: LifeCycle<Record<string, unknown>>) {
-        lifeCycle.hooks.beforeOptionsInit.tap((lifeCycle: testLifeCycleType) => {
+      apply(lifeCycle: LifeCycle) {
+        lifeCycle.hooks.beforeOptionsInit.tap((lifeCycle: testLifeCycle) => {
           expect(lifeCycle.test).toBeUndefined();
         });
         lifeCycle.hooks.alterHTMLTags.tap([
-          (lifeCycle: testLifeCycleType) => {
+          (lifeCycle: testLifeCycle) => {
             lifeCycle.test = test;
           },
-          (lifeCycle: testLifeCycleType) => {
+          (lifeCycle: testLifeCycle) => {
             expect(lifeCycle.test).toBe(test);
           },
         ]);
-        lifeCycle.hooks.beforeElementDefinition.tap((lifeCycle: testLifeCycleType) => {
+        lifeCycle.hooks.beforeElementDefinition.tap((lifeCycle: testLifeCycle) => {
           expect(lifeCycle.test).toBe(test);
+        });
+        lifeCycle.hooks.boforeBootstrap.tap((magicInstance: testMagicInstanceType) => {
+          expect(magicInstance.test).toBeUndefined();
+        });
+        lifeCycle.hooks.beforeMount.tap([
+          (magicInstance: testMagicInstanceType) => {
+            magicInstance.test = test;
+          },
+          (magicInstance: testMagicInstanceType) => {
+            expect(magicInstance.test).toBe(test);
+          },
+        ]);
+        lifeCycle.hooks.beforeUpdated.tap((magicInstance: testMagicInstanceType) => {
+          expect(magicInstance.test).toBe(test);
+        });
+        lifeCycle.hooks.boforeUnmount.tap((magicInstance: testMagicInstanceType) => {
+          expect(magicInstance.test).toBe(test);
           done();
         });
       }


### PR DESCRIPTION
增强 plugins 机制，原本框架暴露的 hook，不足以完全满足框架运行时各阶段 plugin 的注入。增加 boforeBootstrap、beforeMount、beforeUpdated、boforeUnmount 4 个 hook。

例如：基于新增的 beforeBootstrap hook，实现 reactRetargetEventPlugin，解决 react 17 之前合成事件 magic 不生效的问题。

<img width="858" alt="image" src="https://user-images.githubusercontent.com/30647295/169868807-965fc769-45c8-4090-8396-f429cc6d0e8d.png">

开发者可以将 plugin 推送至 npm 仓库，方便其它开发者直接调用。
